### PR TITLE
Add multilanguage twig global variable for KunstmaanBundlesCMS#1159

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,6 +19,7 @@ twig:
         defaultlocale: %defaultlocale%
         requiredlocales: %requiredlocales%
         gtm_code: %analytics.googletagmanager%
+        multilanguage: '%multilanguage%'
         #titlecolor: "#000000"
         #titlebgcolor: "#2997CE"
 


### PR DESCRIPTION
This is needed for https://github.com/Kunstmaan/KunstmaanBundlesCMS/issues/1159 and should come handly later too.

This does not break bc afaik, but single language sites should define it (when upgrading). There won't be error if they don't, just they get the old behavior without this.
There is no upgrade file in this repo, so dunno where to document this change.

The `%multilanguage%` parameter is already in the [parameters.yml.dist](https://github.com/webtown-php/KunstmaanBundlesStandardEdition/blob/master/app/config/parameters.yml.dist#L23), so should be available long before this.
